### PR TITLE
Mark op log as invalid when keys not safe yet

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,6 +12,6 @@ jobs:
     - name: Build
       run: cargo build --verbose
     - name: Run tests
-      run: mkdir dbs&&cargo test --verbose
+      run: mkdir dbs&&cargo test -- --test-threads=1 # threads=1 to avoid the problem with the in disk tests
       # - name: Test replication mult server
       # run: ./tests/test-replication-dbs.sh

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,5 +20,6 @@ thread-id = "*"
 tiny_http = "*"
 clap = "*"
 reqwest = { version="*" , features = ["blocking"]}
+signal-hook = "0.3.9"
 [dev-dependencies]
 tokio-test = "*"

--- a/README.md
+++ b/README.md
@@ -244,3 +244,5 @@ Talk to me @mateusfreira I will help you get it to the scale you need.
 
 [A fast-to-sync/search and space-optimized replication algorithm written in rust, The Nun-db data replication model](https://mateusfreira.github.io/@mateusfreira-a-fast-to-sync-search-and-space-optimized-replication-algorithm-written-in-rust-the-Nun-db-data-replication-model/)
 
+[Leader election in rust the journey towards implementing nun-db leader election](https://mateusfreira.github.io/@mateusfreira-leader-election-rust-the-journey-towards-nun-db-leader-election-implementation/)
+

--- a/src/lib/bo.rs
+++ b/src/lib/bo.rs
@@ -141,6 +141,7 @@ pub struct Databases {
     pub process_id: u128,
     pub user: String,
     pub pwd: String,
+    pub is_oplog_valid: Arc<AtomicBool>,
 }
 
 impl Database {
@@ -276,6 +277,7 @@ impl Databases {
         replication_sender: Sender<String>,
         keys_map: HashMap<String, u64>,
         process_id: u128,
+        is_oplog_valid: bool,
     ) -> Databases {
         let mut id_keys_map: HashMap<u64, String> = HashMap::new();
         let initial_dbs = HashMap::new();
@@ -294,11 +296,12 @@ impl Databases {
             }),
             replication_supervisor_sender,
             replication_sender,
+            node_state: Arc::new(AtomicUsize::new(ClusterRole::StartingUp as usize)),
+            tcp_address,
+            process_id,
             user,
             pwd: pwd.to_string(),
-            tcp_address,
-            node_state: Arc::new(AtomicUsize::new(ClusterRole::StartingUp as usize)),
-            process_id: process_id,
+            is_oplog_valid: Arc::new(AtomicBool::new(is_oplog_valid)),
         };
 
         let admin_db_name = String::from(ADMIN_DB);
@@ -624,6 +627,7 @@ mod tests {
             sender1,
             keys_map,
             1 as u128,
+            true,
         );
         assert_eq!(dbs.map.read().expect("error to lock").keys().len(), 1); //Admin db
 

--- a/src/lib/db_ops.rs
+++ b/src/lib/db_ops.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::bo::*;
+use crate::disk_ops::*;
 
 pub const CONNECTIONS_KEY: &'static str = "$connections";
 
@@ -240,6 +241,11 @@ pub fn get_senders(key: &String, watchers: &Watchers) -> Vec<Sender<String>> {
         Some(watchers_vec) => watchers_vec.clone(),
         _ => Vec::new(),
     };
+}
+
+pub fn safe_shutdown(dbs: &Arc<Databases>) {
+    snapshot_keys(&dbs); // This is more important than the not snapshot_dbs
+    snapshot_all_pendding_dbs(&dbs);
 }
 
 #[cfg(test)]

--- a/src/lib/db_ops.rs
+++ b/src/lib/db_ops.rs
@@ -211,6 +211,7 @@ pub fn create_init_dbs(
     replication_supervisor_sender: Sender<String>,
     replication_sender: Sender<String>,
     keys_map: HashMap<String, u64>,
+    is_oplog_valid: bool,
 ) -> Arc<Databases> {
     let start = SystemTime::now();
     let since_the_epoch = start
@@ -225,6 +226,7 @@ pub fn create_init_dbs(
         replication_sender,
         keys_map,
         since_the_epoch.as_millis(),
+        is_oplog_valid,
     ));
 }
 

--- a/src/lib/disk_ops.rs
+++ b/src/lib/disk_ops.rs
@@ -450,6 +450,9 @@ pub fn get_invalidate_file_read_mode() -> File {
         Ok(f) => f,
     }
 }
+
+/// checks if the oplog files are valid
+/// this is controlled by a file with a single byte, 0 means invalid, 1 valid
 pub fn is_oplog_valid() -> bool {
     let mut f = get_invalidate_file_read_mode();
     let mut buffer = [1; 1];

--- a/src/lib/disk_ops.rs
+++ b/src/lib/disk_ops.rs
@@ -425,7 +425,6 @@ pub fn read_operations_since(since: u64) -> HashMap<String, OpLogRecord> {
 }
 
 pub fn get_invalidate_file_write_mode() -> BufWriter<File> {
-    println!("{}", get_invalidate_file_name());
     BufWriter::with_capacity(
         1,
         OpenOptions::new()
@@ -442,9 +441,9 @@ pub fn get_invalidate_file_read_mode() -> File {
     {
         Err(e) => {
             log::debug!("{:?} will create the file", e);
+            get_invalidate_file_write_mode();// called here to create the file
             OpenOptions::new()
                 .read(true)
-                .create(true)
                 .open(get_invalidate_file_name())
                 .unwrap()
         }

--- a/src/lib/disk_ops.rs
+++ b/src/lib/disk_ops.rs
@@ -53,14 +53,6 @@ pub fn load_keys_map_from_disk() -> HashMap<String, u64> {
     return initial_db;
 }
 
-fn remove_keys_file() {
-    let file_name = get_keys_map_file_name();
-    log::debug!("Will delete {}", file_name);
-    if Path::new(&file_name).exists() {
-        fs::remove_file(file_name).unwrap();
-    }
-}
-
 fn remove_invalidate_oplog_file() {
     let file_name = get_invalidate_file_name();
     log::debug!("Will delete {}", file_name);
@@ -69,6 +61,7 @@ fn remove_invalidate_oplog_file() {
     }
 }
 
+// @todo speed up saving
 pub fn write_keys_map_to_disk(keys: HashMap<String, u64>) {
     let db_file_name = get_keys_map_file_name();
     log::debug!("Will write the keys {} from disk", db_file_name);
@@ -266,7 +259,6 @@ fn remove_op_log_file() {
 
 pub fn clean_op_log_metadata_files() {
     remove_invalidate_oplog_file();
-    remove_keys_file();
     remove_op_log_file();
 }
 

--- a/src/lib/disk_ops.rs
+++ b/src/lib/disk_ops.rs
@@ -407,7 +407,7 @@ pub fn get_invalidate_file_read_mode() -> File {
             OpenOptions::new()
                 .read(true)
                 .create(true)
-                .open(get_op_log_file_name())
+                .open(get_invalidate_file_name())
                 .unwrap()
         }
         Ok(f) => f,

--- a/src/lib/disk_ops.rs
+++ b/src/lib/disk_ops.rs
@@ -441,7 +441,7 @@ pub fn get_invalidate_file_read_mode() -> File {
     {
         Err(e) => {
             log::debug!("{:?} will create the file", e);
-            get_invalidate_file_write_mode();// called here to create the file
+            get_invalidate_file_write_mode(); // called here to create the file
             OpenOptions::new()
                 .read(true)
                 .open(get_invalidate_file_name())
@@ -457,7 +457,6 @@ pub fn is_oplog_valid() -> bool {
     f.read(&mut buffer).unwrap();
     buffer[0] == 1
 }
-
 
 pub fn invalidate_oplog(
     stream: &mut BufWriter<File>,

--- a/src/lib/process_request.rs
+++ b/src/lib/process_request.rs
@@ -391,6 +391,7 @@ mod tests {
             sender2,
             keys_map,
             1 as u128,
+            true,
         ));
 
         dbs.node_state

--- a/src/lib/replication_ops.rs
+++ b/src/lib/replication_ops.rs
@@ -209,6 +209,12 @@ pub async fn start_replication_thread(
     mut replication_receiver: Receiver<String>,
     dbs: Arc<Databases>,
 ) {
+    if dbs
+        .is_oplog_valid
+        .load(std::sync::atomic::Ordering::Relaxed)
+    {
+        clean_op_log_metadata_files();
+    }
     let mut op_log_stream = get_log_file_append_mode();
     let mut invalidate_stream = get_invalidate_file_write_mode();
     loop {

--- a/src/lib/replication_ops.rs
+++ b/src/lib/replication_ops.rs
@@ -209,12 +209,6 @@ pub async fn start_replication_thread(
     mut replication_receiver: Receiver<String>,
     dbs: Arc<Databases>,
 ) {
-    if dbs
-        .is_oplog_valid
-        .load(std::sync::atomic::Ordering::Relaxed)
-    {
-        clean_op_log_metadata_files();
-    }
     let mut op_log_stream = get_log_file_append_mode();
     let mut invalidate_stream = get_invalidate_file_write_mode();
     loop {

--- a/src/lib/security.rs
+++ b/src/lib/security.rs
@@ -30,6 +30,7 @@ mod tests {
             replication_supervisor_sender,
             replication_sender,
             keys_map,
+            true,
         );
 
         let clean_input = clean_string_to_log("auth mateus mateus-123;", &dbs);

--- a/src/main.rs
+++ b/src/main.rs
@@ -63,6 +63,8 @@ fn start_db(
     let is_oplog_valid = disk_ops::is_oplog_valid();
 
     if is_oplog_valid {
+        log::debug!("All fine with op-log metadafiles");
+    } else {
         log::warn!("Nun-db has restarted with op-log in a invalid state, oplog and keys metadafile will be deleted!");
         disk_ops::clean_op_log_metadata_files();
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,6 +59,7 @@ fn start_db(
         Receiver<String>,
     ) = channel(100);
     let keys_map = disk_ops::load_keys_map_from_disk();
+    let is_oplog_valid = disk_ops::is_oplog_valid();
 
     let dbs = lib::db_ops::create_init_dbs(
         user.to_string(),
@@ -67,6 +68,7 @@ fn start_db(
         replication_supervisor_sender,
         replication_sender.clone(),
         keys_map,
+        is_oplog_valid,
     );
 
     disk_ops::load_all_dbs_from_disk(&dbs);
@@ -101,7 +103,6 @@ fn start_db(
         );
         lib::election_ops::start_inital_election(dbs_self_election)
     });
-
 
     let timer = timer::Timer::new();
     let db_snap = dbs.clone();

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ use futures::executor::block_on;
 use futures::join;
 use lib::*;
 use log;
+use signal_hook::{consts::SIGINT, iterator::Signals};
 use std::thread;
 
 use std::sync::Arc;
@@ -61,6 +62,11 @@ fn start_db(
     let keys_map = disk_ops::load_keys_map_from_disk();
     let is_oplog_valid = disk_ops::is_oplog_valid();
 
+    if is_oplog_valid {
+        log::warn!("Nun-db has restarted with op-log in a invalid state, oplog and keys metadafile will be deleted!");
+        disk_ops::clean_op_log_metadata_files();
+    }
+
     let dbs = lib::db_ops::create_init_dbs(
         user.to_string(),
         pwd.to_string(),
@@ -72,6 +78,15 @@ fn start_db(
     );
 
     disk_ops::load_all_dbs_from_disk(&dbs);
+    let mut signals = Signals::new(&[SIGINT]).unwrap();
+    let dbs_to_signal = dbs.clone();
+    thread::spawn(move || {
+        for sig in signals.forever() {
+            println!("Received signal {:?}", sig);
+            db_ops::safe_shutdown(&dbs_to_signal);
+            std::process::exit(0);
+        }
+    });
 
     let db_replication_start = dbs.clone();
     let tcp_address_to_relication = Arc::new(tcp_address.to_string());

--- a/tests/add-values-no-snapshot.in
+++ b/tests/add-values-no-snapshot.in
@@ -1,0 +1,11 @@
+auth mateus mateus
+create-db sample sample-pwd
+use-db sample sample-pwd
+set jose 1
+set maria 2
+set jose 4
+set jose3 4
+set jose4 4
+set jose5 4
+set jose56 4
+

--- a/tests/commons.sh
+++ b/tests/commons.sh
@@ -54,7 +54,7 @@ fi
 if [ $command = "start-1" ] || [ $command = "start-primary" ] || [ $command = "all" ]
 then
     echo "Starting the primary"
-    NUN_DBS_DIR=/tmp/dbs RUST_BACKTRACE=1 ./target/debug/nun-db --user $user -p $user start --http-address "$primaryHttpAddress" --tcp-address "$primaryTcpAddress" --ws-address "127.0.0.1:3058" --replicate-address "$replicaSetAddrs" >>primary.log&
+    NUN_DBS_DIR=./dbs RUST_BACKTRACE=1 ./target/debug/nun-db --user $user -p $user start --http-address "$primaryHttpAddress" --tcp-address "$primaryTcpAddress" --ws-address "127.0.0.1:3058" --replicate-address "$replicaSetAddrs" >>primary.log&
     PRIMARY_PID=$!
     echo $PRIMARY_PID >> .primary.pid
     sleep $timeoutSpeep

--- a/tests/commons.sh
+++ b/tests/commons.sh
@@ -54,7 +54,7 @@ fi
 if [ $command = "start-1" ] || [ $command = "start-primary" ] || [ $command = "all" ]
 then
     echo "Starting the primary"
-    NUN_DBS_DIR=./dbs RUST_BACKTRACE=1 ./target/debug/nun-db --user $user -p $user start --http-address "$primaryHttpAddress" --tcp-address "$primaryTcpAddress" --ws-address "127.0.0.1:3058" --replicate-address "$replicaSetAddrs" >>primary.log&
+    NUN_DBS_DIR=/tmp/dbs RUST_BACKTRACE=1 ./target/debug/nun-db --user $user -p $user start --http-address "$primaryHttpAddress" --tcp-address "$primaryTcpAddress" --ws-address "127.0.0.1:3058" --replicate-address "$replicaSetAddrs" >>primary.log&
     PRIMARY_PID=$!
     echo $PRIMARY_PID >> .primary.pid
     sleep $timeoutSpeep

--- a/tests/run-all.sh
+++ b/tests/run-all.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+
+./tests/test-fail-invalid-op-log-dbs.sh
+status=$?
+if [ $status != 0 ]
+then
+	echo "Fail fail-invalid-op-log" 
+	exit 1
+fi
+
+./tests/test-fail-primary-dbs.sh
+
+status=$?
+if [ $status != 0 ]
+then
+	echo "Fail fail-primary" 
+	exit 2
+fi
+
+./tests/test-replication-dbs.sh
+status=$?
+if [ $status != 0 ]
+then
+	echo "Fail test-replication-dbs" 
+	exit 3
+fi
+

--- a/tests/test-fail-invalid-op-log-dbs.sh
+++ b/tests/test-fail-invalid-op-log-dbs.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+echo "Add trap if all"
+trap "kill 0" EXIT
+
+./tests/commons.sh clean
+echo "Start primary" 
+./tests/commons.sh start-1
+echo "Start secoundary" 
+./tests/commons.sh start-2
+echo "Send values" 
+nc localhost 3017 < tests/add-values-no-snapshot.in
+
+size=$(ls -lh /tmp/dbs/oplog-nun.op | awk '{ print $5 }')
+if [ $size == "0B" ]
+then
+	echo "Invalid oplog size. it should have records!";
+	exit 2
+fi
+
+echo "Kill primary" 
+cat .primary.pid | xargs -I '{}' kill -9 {}
+cat .secoundary.pid | xargs -I '{}' kill -9 {}
+
+echo "Start primary" 
+./tests/commons.sh start-1
+size=$(ls -lh /tmp/dbs/oplog-nun.op | awk '{ print $5 }')
+if [ $size != "0B" ]
+then
+	echo "Invalid op size in the end";
+	exit 3
+fi
+./tests/commons.sh start-2
+./tests/commons.sh kill
+./tests/commons.sh clean
+
+echo "Great success \o/" 
+

--- a/tests/test-fail-primary-dbs.sh
+++ b/tests/test-fail-primary-dbs.sh
@@ -27,10 +27,8 @@ fi
 if [ $command = "start-1" ] || [ $command = "all" ]
 then
 echo "Starting the primary"
-NUN_DBS_DIR=/tmp/dbs RUST_BACKTRACE=1 ./target/debug/nun-db --user $user -p $user start --http-address "$primaryHttpAddress" --tcp-address "$primaryTcpAddress" --ws-address "127.0.0.1:3058" --replicate-address "$replicaSetAddrs" >primary.log&
-PRIMARY_PID=$!
-echo $PRIMARY_PID >> .primary.pid
-sleep $timeoutSpeep
+     ./tests/commons.sh start-1
+    sleep $timeoutSpeep
 fi
 
 if [ $command = "start-2" ] || [ $command = "all" ]
@@ -143,7 +141,7 @@ then
 
     echo "Will start the tests of failure"
 
-    kill -9 $PRIMARY_PID
+    cat .primary.pid | xargs -I '{}' kill -9 {}
     echo 'Rebuilding the cluster'
     sleep 10
     sleep $timeoutSpeep

--- a/tests/test-fail-primary-dbs.sh
+++ b/tests/test-fail-primary-dbs.sh
@@ -203,5 +203,7 @@ then
       fi
 fi
 
+echo "All good \o/"
+
 exit 0
 


### PR DESCRIPTION
As we keep a keys metadata file and store it only when any database does a snapshot, it was possible that if new keys were added and the server restarted before saving the keys to disk. So when the server restarted in op-log, there would be keys ids without equivalent to the id stored. To solve this problem, we had two options.

1. Store new keys synchronously: I wouldn't say I liked this option because it would slow down operation since now they would not happen only in memory.


2. Control validation invalidation of the oplog file while new keys are not yet safe saved. This seemed to me as the best option. It required an addiction control to know if the oplog-file is safe, but I can maintain a file with a single byte on disk to keep it over restarts. 


I decided to go with option 2, focusing on performance over safety. So, next, I am presenting the main changes I needed to make.
* Check in the startup if the oplog is valid and clean up if not [here](https://github.com/mateusfreira/nun-db/pull/46/files#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR63).
* Mark op-log as invalid when new keys are added [here](https://github.com/mateusfreira/nun-db/pull/46/files#diff-89278152a2056d58a020f3bc650d361896aab94b545e2fe295af5eb51d46b411R198)
* Mark op-log as valid when the keys file is saved [here](https://github.com/mateusfreira/nun-db/pull/46/files#diff-1ecd79b0edbd75ca1397db1803ca91cf12d19c7459ef558f828da0d836fae710R243)
* Finally, I added a trap to the terminate signal to save the keys file before shutting down the process to ensure this error will rarely happen [here](https://github.com/mateusfreira/nun-db/pull/46/files#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR88).

It is safe to clean the op-log because the Database will do the full sync if the op-log is missing.
Check the full PR [here](https://github.com/mateusfreira/nun-db/pull/46)
