### PR TITLE
Add debug command

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ timer = "*"
 chrono = "*"
 thread-id = "*"
 tiny_http = "*"
-clap = "*"
+clap = "2.34.0"
 reqwest = { version="*" , features = ["blocking"]}
 signal-hook = "0.3.9"
 atomic_float = "0.1.0"

--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ Done you now have nun-db running in your docker and exposing all the ports to be
 
 [Integration tests in rust a multi-process test example](https://mateusfreira.github.io/@mateusfreira-integration-tests-for-rust-apps-testing-command-line-tools-in-rust/)
 
+[Writing a prometheus exporter in rust from idea to grafana chart](https://mateusfreira.github.io/@mateusfreira-writing-a-prometheus-exporter-in-rust-from-idea-to-grafana-chart/)
+
 ## Diagram
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ Done you now have nun-db running in your docker and exposing all the ports to be
 
 [Writing a prometheus exporter in rust from idea to grafana chart](https://mateusfreira.github.io/@mateusfreira-writing-a-prometheus-exporter-in-rust-from-idea-to-grafana-chart/)
 
+[Why does Nun-db we have a Debug command?](https://mateusfreira.github.io/@mateusfreira-the-nun-db-debug-command/)
+
 ## Diagram
 
 ```bash
@@ -299,6 +301,22 @@ e.gs
 metrics-state;
 response: 
 metrics-state pending_ops: 0, op_log_file_size: 0, op_log_count: 0,replication_time_moving_avg: 0.0, get_query_time_moving_avg: 0.0
+```
+
+### Debug
+#### Context
+- [x] Require admin auth
+- [ ] Require db auth
+- [ ] Replicate? How? (replicate-increment)
+- [ ] Register Oplog? How? (Update)
+
+The debug command holds admin queries for Nun-db, like, for example, checking the messages that are pending replication from a specific node in the cluster.
+
+e.gs
+```
+debug pending_ops
+#result
+pending_ops #list-of-pending-ops#
 ```
 
 

--- a/src/lib/bo.rs
+++ b/src/lib/bo.rs
@@ -582,6 +582,22 @@ impl Databases {
             count
         )
     }
+
+    pub fn get_pending_messages_debug(&self) -> Vec<String> {
+        let pending_opps = self.pending_opps.read().unwrap();
+        let messages = pending_opps.values();
+        messages
+            .into_iter()
+            .map(|p_m|
+                format!("message: \"{message}\", opp_id: {opp_id}, ack_count: {ack_count}, replicate_count: {replicate_count} ",
+                opp_id = p_m.opp_id,
+                message = p_m.message.to_string(),
+                ack_count = p_m.ack_count.load(Ordering::Relaxed),
+                replicate_count = p_m.replicate_count.load(Ordering::Relaxed),
+                )
+            )
+            .collect()
+    }
 }
 
 pub struct Watchers {
@@ -740,6 +756,9 @@ pub enum Request {
     Acknowledge {
         opp_id: u64,
         server_name: String,
+    },
+    Debug {
+        command: String,
     },
 }
 

--- a/src/lib/parse_request.rs
+++ b/src/lib/parse_request.rs
@@ -428,6 +428,18 @@ impl Request {
                     server_name,
                 })
             }
+            Some("debug") => {
+                let debug_command = match command.next() {
+                    Some(command) => command.to_string(),
+                    None => {
+                        return Err(format!("command is mandatory"));
+                    }
+                };
+
+                Ok(Request::Debug {
+                    command: debug_command,
+                })
+            }
             Some(cmd) => Err(format!("unknown command: {}", cmd)),
             _ => Err(format!("no command sent")),
         };
@@ -834,6 +846,34 @@ mod tests {
                 }
             }
             _ => Err(String::from("Invalid parsing")),
+        }
+    }
+
+    #[test]
+    fn should_parse_debug_command() -> Result<(), String> {
+        match Request::parse("debug pending_messages") {
+            Ok(Request::Debug { command }) => {
+                if command == "pending_messages" {
+                    Ok(())
+                } else {
+                    Err(String::from("Invalid command"))
+                }
+            }
+            _ => Err(String::from("Invalid parsing")),
+        }
+    }
+
+    #[test]
+    fn should_parse_debug_command_invalid() -> Result<(), String> {
+        match Request::parse("debug") {
+            Err(message) => {
+                if message == "command is mandatory" {
+                    Ok(())
+                } else {
+                    Err(String::from("Invalid error message"))
+                }
+            }
+            _ => Err(String::from("Should not have parsed!!")),
         }
     }
 }

--- a/tests/metrics-state.rs
+++ b/tests/metrics-state.rs
@@ -13,8 +13,9 @@ mod tests {
 
         helpers::nundb_exec_primary("create-db test test-pwd; use-db test test-pwd;set-safe name 0 mateus; set-safe name 0 maria;set-safe name 1 mateus; set-safe name 0 maria;get-safe name");
 
-        helpers::nundb_exec_primary("metrics-state")
-            .stdout(predicate::str::contains("op_log_file_size: 75, op_log_count: 3")); //3 transations
+        helpers::nundb_exec_primary("metrics-state").stdout(predicate::str::contains(
+            "op_log_file_size: 75, op_log_count: 3",
+        )); //3 transations
 
         db_process.kill()?;
         Ok(())


### PR DESCRIPTION
# What is the debug command?
The debug command holds admin queries for Nun-db, like, for example, checking the messages that are pending replication from a specific node in the cluster.

For more information please read [here](https://mateusfreira.github.io/@mateusfreira-the-nun-db-debug-command/) where I document the decisions to add this command

