### PR TITLE
Fix ack command

### DIFF
--- a/src/lib/bo.rs
+++ b/src/lib/bo.rs
@@ -537,10 +537,32 @@ impl Databases {
         members.remove(&name.to_string());
     }
 
-    pub fn add_pending_opp(&self, replication_message: ReplicationMessage) {
-        replication_message.replicated();
-        let mut pending_opps = self.pending_opps.write().unwrap();
-        pending_opps.insert(replication_message.opp_id, replication_message);
+    /**
+     * Registers the message as pending from replication and return the message_to_replicate.
+     * The method ensures that the message are registered only once
+     * @todo this method has 2 locks for the pending_opps to make it safe ideally no lock would be
+     * needed but for now they are needed.
+     */
+    pub fn register_pending_opp(&self, op_log_id: u64, message: String) -> String {
+        let exists = { self.pending_opps.read().unwrap().contains_key(&op_log_id) }; //To limit the scope of the read lock
+        if !exists {
+            let replication_message = ReplicationMessage::new(op_log_id, message.clone());
+            let message_to_replicate = replication_message.message_to_replicate();
+            replication_message.replicated();
+            let mut pending_opps = self.pending_opps.write().unwrap();
+            pending_opps.insert(replication_message.opp_id, replication_message);
+            message_to_replicate
+        } else {
+            let message_to_replicate = {
+                self.pending_opps
+                    .read()
+                    .unwrap()
+                    .get(&op_log_id)
+                    .unwrap()
+                    .message_to_replicate()
+            };// To limit the scope of the read lock
+            message_to_replicate
+        }
     }
 
     pub fn acknowledge_pending_opp(&self, opp_id: u64, server_name: String) {

--- a/src/lib/bo.rs
+++ b/src/lib/bo.rs
@@ -538,6 +538,7 @@ impl Databases {
     }
 
     pub fn add_pending_opp(&self, replication_message: ReplicationMessage) {
+        replication_message.replicated();
         let mut pending_opps = self.pending_opps.write().unwrap();
         pending_opps.insert(replication_message.opp_id, replication_message);
     }

--- a/tests/replication-tests.rs
+++ b/tests/replication-tests.rs
@@ -42,7 +42,7 @@ mod tests {
         .success()
         .stdout(predicate::str::contains("empty;empty"));
 
-        helpers::wait_seconds(1); //Wait 1s to the replication
+        helpers::wait_seconds(3); //Wait 3s to the replication
 
         helpers::nundb_exec(
             &helpers::SECOUNDAR_HTTP_URI.to_string(),


### PR DESCRIPTION
In the example I found checkout what happened: 
```bash

### Pending message
message: "replicate org-559 lastTreatment { "id": 1641746754477, ...restOfTheProject}}", opp_id: 1641746754499484856, ack_count: 1, replicate_count: 2 
```

What I noticed was that the message of ack was processed to close the the message
```bash
[2022-01-09T16:45:54.498664265Z  'set lastTreatment { "id": 1641746754477, "value" : {"$persisted":true,"user":618812,"id":5608309,...}}' in 8.021µs
# ...
[2022-01-09T16:45:54.504963203Z nun_db::lib::bo] Acknowledging invalid opp 1641746754499484856
# 6ms latter
[2022-01-09T16:45:54.504980963Z nun_db::lib::process_request]  'ack 1641746754499484856 nun-db-2-1.nun-db-2.nun-db.svc.cluster.local:3019' in 28.6µs
[2022-01-09T16:45:54.509355868Z nun_db::lib::process_request] 'ack 1641746754499484856 nun-db-2-0.nun-db-2.nun-db.svc.cluster.local:3019
    ' in 10.56µs
```

In the implementation before this MR was made this way: 
```rust
fn replicate_message_to_secoundary(op_log_id: u64, message: String, dbs: &Arc<Databases>) {
//...
    for (_name, member) in state.members.lock().unwrap().iter() { // Loop in all nodes in the cluster
        match member.role {
            ClusterRole::Secoundary => {
                replicate_message.replicated();
                replicate_if_some(
                    &member.sender,
                    &replicate_message.message_to_replicate(),
                    &member.name,
                ) // Send message to the node specific thread to be sent over tcp (As a separated thread it can run super fast) 
            }
            ClusterRole::Primary => (),
            ClusterRole::StartingUp => (),
        }
    }

    if replicate_message.is_replicated() {
        dbs.add_pending_opp(replicate_message);// Only here register the Database (Before this point it cannot be ack)
    }
// The propose fix is simple register the pending ops before sending to any node this way it is impossible making the possible state impossible. 
}

```

### The propose fix is simple register the pending ops before sending to any node this way it is impossible making the possible state impossible. 
